### PR TITLE
Add image search result cache through a hash array

### DIFF
--- a/JavOldDriver.user.js
+++ b/JavOldDriver.user.js
@@ -484,7 +484,7 @@
                             queryUrl = 'https://javstore.net' + (/^\//.test(queryUrl) ? "" : "/") + queryUrl.replace(/^\.+\/?/, "");
                         }
                         //异步请求调用内页详情的访问地址
-                        return request(queryUrl, 'http://javstore.net/').then((result) => {
+                        return request(queryUrl, 'https://javstore.net/').then((result) => {
                             if (result.loadstuts) {
                                 let doc = Common.parsetext(result.responseText);
                                 let img_array = $(doc).find('.category_news_main_right>.news>a>img');


### PR DESCRIPTION
1. Add image search result cache through a hash array. It will reduce many requests to search the images if it had searched before in a caching period. Values `maxImgHashNum` and `maxImgCacheTimeSeconds` contorl the hash array and cache time.
2. Fix getting avcode rule, function `getAvCode`.
3. Add a empty image if image not found. Empty image use a base64 image data value `emptyImageData` instead.
3. Fix something that maybe cause errors.